### PR TITLE
Improved cookie handling, POST method for deletes

### DIFF
--- a/database/sql/04-tables.sql
+++ b/database/sql/04-tables.sql
@@ -222,7 +222,7 @@ CREATE TABLE user_reset_password
 -- -----------------------------------------------------------
 -- LOGIN
 --  -----------------------------------------------------------
-CREATE TYPE LOGIN_RESULT_TYPE AS ENUM ('SUCCESS', 'INVALID_CREDENTIALS', 'DISABLED', 'LOCKED');
+CREATE TYPE LOGIN_RESULT_TYPE AS ENUM ('SUCCESS', 'INVALID_CREDENTIALS', 'DISABLED', 'LOCKED', 'CHANGED');
 CREATE TYPE LOGIN_TYPE AS ENUM ('FORM', 'COOKIE', 'RESET_PWD', 'USER_CREATE');
 
 create table login

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/login/LoginResult.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/login/LoginResult.java
@@ -1,5 +1,5 @@
 package com.redshiftsoft.tesla.dao.login;
 
 public enum LoginResult {
-    SUCCESS, INVALID_CREDENTIALS, DISABLED, LOCKED
+    SUCCESS, INVALID_CREDENTIALS, DISABLED, LOCKED, CHANGED
 }

--- a/service-dao/src/main/sql/schema-changes.sql
+++ b/service-dao/src/main/sql/schema-changes.sql
@@ -1,3 +1,6 @@
 -- ============================================================================
 -- File for SQL that will change the schema.  Clear this file after prod deploy.
 -- ============================================================================
+set search_path to supercharge;
+
+ALTER TYPE LOGIN_RESULT_TYPE ADD VALUE 'CHANGED';

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/filter/CookieHelper.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/filter/CookieHelper.java
@@ -1,5 +1,8 @@
 package com.redshiftsoft.tesla.web.filter;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -26,16 +29,16 @@ public class CookieHelper {
     }
 
     /**
-     * Add the specified cookie to the the response.
+     * Add the specified cookie builder to the the response.
      */
-    public static void addCookie(final HttpServletRequest request, final HttpServletResponse response, Cookie cookie) {
+    public static void addCookie(final HttpServletRequest request, final HttpServletResponse response, ResponseCookie.ResponseCookieBuilder cookie) {
         /* Important security measure: see design decisions on cookie security. */
         if (request.isSecure()) {
-            cookie.setSecure(true);
+            cookie = cookie.secure(true);
         } else if ("development".equals(System.getProperty("spring.profiles.active"))) {
-            cookie.setSecure(false);
+            cookie = cookie.secure(false);
         }
-        response.addCookie(cookie);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.sameSite("Lax").build().toString());
     }
 
     /**

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
@@ -38,7 +38,7 @@ public class ChangeLogController {
 
     @RequestMapping(method = RequestMethod.GET, value = "/allChanges")
     @ResponseBody
-    public List<ChangeLogDTO> allChanges(@RequestParam(value = "count", required = false) Integer count) {
+    public List<ChangeLogDTO> allChanges(@RequestParam(required = false) Integer count) {
         List<ChangeLogDTO> changes = cachingHandler.getValues();
         if (count != null) {
             int toIndex = Math.min(count, changes.size());
@@ -103,9 +103,9 @@ public class ChangeLogController {
 
     @PreAuthorize("hasAnyRole('editor')")
     @Transactional
-    @RequestMapping(method = RequestMethod.GET, value = "/changes/delete/{changeId}")
+    @RequestMapping(method = RequestMethod.POST, value = "/changes/delete")
     @ResponseBody
-    public void deleteChange(@PathVariable Integer changeId) {
+    public void deleteChange(@RequestParam Integer changeId) {
         LOG.info("Deleting change: " + changeId);
         changeLogDAO.delete(changeId);
         cachingHandler.reset();

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/feature/FeatureController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/feature/FeatureController.java
@@ -2,6 +2,7 @@ package com.redshiftsoft.tesla.web.mvc.feature;
 
 import com.redshiftsoft.tesla.dao.feature.Feature;
 import com.redshiftsoft.tesla.dao.feature.FeatureDAO;
+import com.redshiftsoft.tesla.web.filter.CookieHelper;
 import com.redshiftsoft.tesla.web.mvc.JsonResponse;
 import com.redshiftsoft.util.NumberUtils;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -11,6 +12,7 @@ import org.springframework.transaction.interceptor.TransactionAspectSupport;
 import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.logging.Level;
@@ -72,8 +74,8 @@ public class FeatureController {
     @Transactional
     @ResponseBody
     @PreAuthorize("hasAnyRole('admin')")
-    @RequestMapping(method = RequestMethod.GET, value = "/delete/{featureId}")
-    public JsonResponse deleteChange(@PathVariable Integer featureId) {
+    @RequestMapping(method = RequestMethod.POST, value = "/delete")
+    public JsonResponse deleteChange(@RequestParam Integer featureId) {
         featureDAO.delete(featureId);
         return JsonResponse.success();
     }
@@ -81,14 +83,15 @@ public class FeatureController {
     @Transactional
     @ResponseBody
     @RequestMapping(method = RequestMethod.GET, value = "/check")
-    public JsonResponse checkForNewFeatures(HttpServletResponse response,
+    public JsonResponse checkForNewFeatures(HttpServletRequest request,
+                                            HttpServletResponse response,
                                             @CookieValue(name = FeatureCookie.COOKIE_NAME, required = false) String lastSeenFeatureId) {
         Integer lastSeenFeatureIdInt = NumberUtils.parse(lastSeenFeatureId, Integer.class);
         int latestFeatureId = featureDAO.getLatestFeatureId();
 
         // CASE 1: There is no feature cookie, or there is, but the last seen feature is OLD.
         if (lastSeenFeatureIdInt == null || (lastSeenFeatureIdInt < latestFeatureId)) {
-            response.addCookie(new FeatureCookie(latestFeatureId));
+            CookieHelper.addCookie(request, response, FeatureCookie.from(latestFeatureId));
             return JsonResponse.success("new features");
         }
         // CASE 2: They have already been notified of all the new features.

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/feature/FeatureCookie.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/feature/FeatureCookie.java
@@ -1,19 +1,19 @@
 package com.redshiftsoft.tesla.web.mvc.feature;
 
-import javax.servlet.http.Cookie;
+import org.springframework.http.ResponseCookie;
 
 /**
  * This cookie stores the featureId of the last feature the user was notified of.
  */
-public class FeatureCookie extends Cookie {
+public class FeatureCookie {
 
     public static final String COOKIE_NAME = "feature";
 
-    public FeatureCookie(int featureId) {
-        super(COOKIE_NAME, String.valueOf(featureId));
-        // This cookie should live forever.
-        setMaxAge(Integer.MAX_VALUE);
-        //
-        setPath("/");
+    public static ResponseCookie.ResponseCookieBuilder from(int featureId) {
+        return ResponseCookie
+            .from(COOKIE_NAME, String.valueOf(featureId))
+            // This cookie should live forever.
+            .maxAge(Integer.MAX_VALUE)
+            .path("/");
     }
 }

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/SiteEditController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/SiteEditController.java
@@ -60,7 +60,7 @@ public class SiteEditController {
     @PreAuthorize("hasAnyRole('editor')")
     @RequestMapping(method = RequestMethod.GET, value = "/load")
     @ResponseBody
-    public SiteEditDTO load(@RequestParam("siteId") Integer siteId) {
+    public SiteEditDTO load(@RequestParam Integer siteId) {
         /* Bypass cache here because this is used for the admin/edit-site page. */
         Site site = siteDAO.getById(siteId);
         return SiteEditDTOFunctions.transform(site);
@@ -160,10 +160,10 @@ public class SiteEditController {
     // - - - - - - - - - -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     @PreAuthorize("hasRole('admin')")
-    @RequestMapping(method = RequestMethod.GET, value = "/delete")
+    @RequestMapping(method = RequestMethod.POST, value = "/delete")
     @ResponseBody
     @Transactional
-    public void delete(@RequestParam("siteId") int siteId) {
+    public void delete(@RequestParam int siteId) {
         siteDAO.delete(siteId);
         dbInfoDAO.setLastModifiedToNow();
     }
@@ -179,7 +179,7 @@ public class SiteEditController {
     @RequestMapping(method = RequestMethod.GET, value = "/changeDetail")
     @ResponseBody
     @Transactional
-    public List<SiteChangeDTO> listChangeDetail(@RequestParam("siteId") int siteId) {
+    public List<SiteChangeDTO> listChangeDetail(@RequestParam int siteId) {
         return siteChangeDAO.list(siteId).stream()
                 .map(x -> new SiteChangeDTO(
                         x.getSiteId(),

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/user/UserCreateController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/user/UserCreateController.java
@@ -103,7 +103,7 @@ public class UserCreateController {
              *  Reload the user from DB before creating cookie and hash from it so we use exact values we will use in future.
              */
             user = userDAO.getById(user.getId());
-            CookieHelper.addCookie(request, response, LoginCookie.fromUser(user));
+            CookieHelper.addCookie(request, response, LoginCookie.from(user));
             loginDAO.insertAttempt(LoginAttemptFactory.successAccountCreated(request, user));
 
             emailSender.send(user);

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/userlogin/LoginAttemptFactory.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/userlogin/LoginAttemptFactory.java
@@ -30,6 +30,14 @@ public class LoginAttemptFactory {
     }
 
     // - - - - - - - - - - -
+    // LoginResult = CHANGED
+    // - - - - - - - - - - -
+
+    public static LoginAttempt changedPassword(HttpServletRequest request, User user) {
+        return new LoginAttempt(user, LoginResult.CHANGED, LoginType.RESET_PWD, request.getRemoteAddr(), request.getLocale());
+    }
+
+    // - - - - - - - - - - -
     // LoginResult = INVALID_CREDENTIALS
     // - - - - - - - - - - -
 

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/userlogin/LoginCookie.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/userlogin/LoginCookie.java
@@ -4,7 +4,8 @@ import com.google.common.io.BaseEncoding;
 import com.redshiftsoft.tesla.dao.user.User;
 import com.redshiftsoft.util.PasswordHashLogic;
 
-import javax.servlet.http.Cookie;
+import org.springframework.http.ResponseCookie;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -27,7 +28,7 @@ import static com.redshiftsoft.util.StringTools.isNotEmpty;
  * <p/>
  * SECURITY NOTES: Like a session cookie, if this cookie is stolen the user account is compromised.
  */
-public class LoginCookie extends Cookie {
+public class LoginCookie {
 
     private static final Logger LOG = Logger.getLogger(LoginCookie.class.getName());
 
@@ -48,16 +49,13 @@ public class LoginCookie extends Cookie {
 
     private static final PasswordHashLogic cookieHashLogic = new PasswordHashLogic(PasswordHashLogic.PBKDF2_WITH_HMAC_SHA256, 32, 10);
 
-    public LoginCookie(final User user) {
-        super(NAME, user.getId() + DELIMITER + generateCode(user));
-        setPath("/");
-        setMaxAge(Integer.MAX_VALUE);
-        setHttpOnly(true);
-        setSecure(true);
-    }
-
-    public static LoginCookie fromUser(User user) {
-        return new LoginCookie(user);
+    public static ResponseCookie.ResponseCookieBuilder from(final User user) {
+        return ResponseCookie
+            .from(NAME, user.getId() + DELIMITER + generateCode(user))
+            .path("/")
+            .maxAge(Integer.MAX_VALUE)
+            .httpOnly(true)
+            .secure(true);
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/userlogin/UserLoginController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/userlogin/UserLoginController.java
@@ -50,8 +50,8 @@ public class UserLoginController {
     @RequestMapping(value = "", method = RequestMethod.POST)
     @ResponseBody
     public UserLoginResponse login(HttpServletRequest request, HttpServletResponse response,
-                                   @RequestParam(value = "username", required = false) String username,
-                                   @RequestParam(value = "password", required = false) String password) {
+                                   @RequestParam(required = false) String username,
+                                   @RequestParam(required = false) String password) {
 
         LOG.info("login username=" + username);
 
@@ -77,7 +77,7 @@ public class UserLoginController {
         }
         LOG.info("login SUCCESS username=" + username);
         loginDAO.insertAttempt(successForm(request, user));
-        CookieHelper.addCookie(request, response, LoginCookie.fromUser(user));
+        CookieHelper.addCookie(request, response, LoginCookie.from(user));
         return UserLoginResponse.success(user);
     }
 

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/userroute/UserRouteController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/userroute/UserRouteController.java
@@ -64,9 +64,9 @@ public class UserRouteController {
 
     @PreAuthorize("isAuthenticated()")
     @Transactional
-    @RequestMapping(method = RequestMethod.GET, value = "/delete/{routeId}")
+    @RequestMapping(method = RequestMethod.POST, value = "/delete")
     @ResponseBody
-    public JsonResponse delete(@PathVariable Integer routeId) {
+    public JsonResponse delete(@RequestParam("id") Integer routeId) {
         User threadUser = Security.user();
         Integer userId = threadUser.getId();
         LOG.info("userId=" + userId + "; routeId=" + routeId);


### PR DESCRIPTION
- Use SameSite cookies (most browsers have enabled this by default for the last 3 years)
- Use POST methods for all endpoints that affect data (requires frontend and admin changes to enable)
- Improved session handling when the user's data changes