### PR TITLE
Manage changelogs

### DIFF
--- a/database/sql/04-tables.sql
+++ b/database/sql/04-tables.sql
@@ -133,6 +133,7 @@ create table changelog
     change_type   change_type      not null,
     site_status   site_status_type not null,
     modified_date timestamptz      not null default current_timestamp,
+    notify        boolean          not null default true,
     user_id       int              null,
     CONSTRAINT fk_changelog_1 foreign key (site_id) references site (site_id)
         on update cascade

--- a/database/sql/04-tables.sql
+++ b/database/sql/04-tables.sql
@@ -132,12 +132,15 @@ create table changelog
     change_date   timestamptz      not null,
     change_type   change_type      not null,
     site_status   site_status_type not null,
-    modified_date timestamptz      not null default current_timestamp
-);
-alter table changelog
-    add constraint fk_changelog_1 foreign key (site_id) references site (site_id)
+    modified_date timestamptz      not null default current_timestamp,
+    user_id       int              null,
+    CONSTRAINT fk_changelog_1 foreign key (site_id) references site (site_id)
         on update cascade
-        on delete cascade;
+        on delete cascade,
+    CONSTRAINT fk_changelog_2 foreign key (user_id) references users (user_id)
+        on update cascade
+        on delete cascade
+);
 alter sequence changelog_id_seq restart with 100000;
 
 -- -----------------------------------------------------------

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLog.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLog.java
@@ -38,27 +38,10 @@ public class ChangeLog implements Comparable<ChangeLog> {
     // PERMIT, CONSTRUCTION, OPEN
     private SiteStatus siteStatus;
 
+    private boolean notify;
     private int stallCount;
     private int powerKilowatt;
     private boolean otherEVs;
-
-    /**
-     * Factory method with all fields required to persist.
-     */
-    public static ChangeLog toPersist(int siteId, ChangeType changeType, SiteStatus siteStatus, Instant date, Instant modifiedInstant) {
-        return new ChangeLog(siteId, changeType, siteStatus, date, modifiedInstant);
-    }
-
-    public ChangeLog() {
-    }
-
-    private ChangeLog(int siteId, ChangeType changeType, SiteStatus siteStatus, Instant date, Instant modifiedInstant) {
-        this.siteId = siteId;
-        this.date = date;
-        this.changeType = changeType;
-        this.siteStatus = siteStatus;
-        this.modifiedInstant = modifiedInstant;
-    }
 
     public int getId() {
         return id;
@@ -92,6 +75,14 @@ public class ChangeLog implements Comparable<ChangeLog> {
 
     public void setSiteStatus(SiteStatus siteStatus) {
         this.siteStatus = siteStatus;
+    }
+
+    public boolean getNotify() {
+        return notify;
+    }
+
+    public void setNotify(boolean notify) {
+        this.notify = notify;
     }
 
     public int getStallCount() {

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogDAO.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogDAO.java
@@ -113,6 +113,7 @@ public class ChangeLogDAO extends BaseDAO {
         cl.setChangeType(ChangeType.valueOf(rs.getString(c++)));
         cl.setSiteStatus(SiteStatus.valueOf(rs.getString(c++)));
         cl.setModifiedInstant(Instant.ofEpochMilli(rs.getTimestamp(c++).getTime()));
+        cl.setNotify(rs.getBoolean(c++));
         cl.setUserId(rs.getInt(c++));
         if (rs.getMetaData().getColumnCount() >= c) {
             cl.setUsername(rs.getString(c));

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogDAO.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogDAO.java
@@ -3,6 +3,7 @@ package com.redshiftsoft.tesla.dao.changelog;
 
 import com.redshiftsoft.tesla.dao.BaseDAO;
 import com.redshiftsoft.tesla.dao.site.SiteStatus;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Component;
@@ -17,7 +18,6 @@ import java.util.Map;
 public class ChangeLogDAO extends BaseDAO {
 
     private static final ChangeLogRowMapper CHANGE_LOG_ROW_MAPPER = new ChangeLogRowMapper();
-
     public ChangeLog getById(int id) {
         String sql = ChangeLogRowMapper.SELECT + " where cl.id=?";
         return getJdbcTemplate().queryForObject(sql, CHANGE_LOG_ROW_MAPPER, id);
@@ -45,7 +45,12 @@ public class ChangeLogDAO extends BaseDAO {
         return resultMap;
     }
 
-    public void insert(ChangeLog changeLog) {
+    public List<ChangeLogEdit> getChangeLogEdits(int siteId) {
+        String sql = "select changelog.*, username from changelog left join users using (user_id) where site_id = ? order by change_date desc";
+        return getJdbcTemplate().query(sql, CHANGE_LOG_EDIT_ROW_MAPPER, siteId);
+    }
+
+    public void insert(ChangeLogEdit changeLog) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         getJdbcTemplate().update(new InsertChangeLogPreparedStatementCreator(changeLog), keyHolder);
         changeLog.setId((Integer) keyHolder.getKeys().get("id"));
@@ -60,6 +65,12 @@ public class ChangeLogDAO extends BaseDAO {
         String sql = "select count(*) from changelog where id=?";
         Long count = getJdbcTemplate().queryForObject(sql, Long.class, changeLogId);
         return count != 0;
+    }
+
+    public int update(int id, Instant date, SiteStatus status, int userId) {
+        String UPDATE_SQL = "UPDATE changelog SET change_date = ?, site_status = ?::SITE_STATUS_TYPE, " +
+                            "modified_date = now(), user_id = ? WHERE id = ? RETURNING site_id";
+        return getJdbcTemplate().queryForObject(UPDATE_SQL, Integer.class, toTimestamp(date), status.toString(), userId, id);
     }
 
     /* Returns map <siteId, days at current status> */
@@ -80,6 +91,35 @@ public class ChangeLogDAO extends BaseDAO {
         }
         return resultMap;
     }
+
+    public List<ChangeLogEdit> setFirstToAdded(int siteId) {
+        String UPDATE_SQL = "UPDATE changelog o SET change_type = " +
+                                    "CASE (select min(i.change_date) from changelog i " +
+                                            "where i.site_id = o.site_id) " +
+                                    "WHEN change_date THEN 'ADD'::CHANGE_TYPE " +
+                                    "ELSE 'UPDATE'::CHANGE_TYPE END WHERE site_id = ? " +
+                            "RETURNING o.*, (select username from users where user_id = o.user_id)";
+        return getJdbcTemplate().query(UPDATE_SQL, CHANGE_LOG_EDIT_ROW_MAPPER, siteId);
+    }
+
+    private static final RowMapper<ChangeLogEdit> CHANGE_LOG_EDIT_ROW_MAPPER = (rs, rowNum) -> {
+        ChangeLogEdit cl = new ChangeLogEdit();
+
+        int c = 1;
+
+        cl.setId(rs.getInt(c++));
+        cl.setSiteId(rs.getInt(c++));
+        cl.setDate(Instant.ofEpochMilli(rs.getTimestamp(c++).getTime()));
+        cl.setChangeType(ChangeType.valueOf(rs.getString(c++)));
+        cl.setSiteStatus(SiteStatus.valueOf(rs.getString(c++)));
+        cl.setModifiedInstant(Instant.ofEpochMilli(rs.getTimestamp(c++).getTime()));
+        cl.setUserId(rs.getInt(c++));
+        if (rs.getMetaData().getColumnCount() >= c) {
+            cl.setUsername(rs.getString(c));
+        }
+
+        return cl;
+    };
 
 
 }

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogDAO.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogDAO.java
@@ -67,10 +67,10 @@ public class ChangeLogDAO extends BaseDAO {
         return count != 0;
     }
 
-    public int update(int id, Instant date, SiteStatus status, int userId) {
-        String UPDATE_SQL = "UPDATE changelog SET change_date = ?, site_status = ?::SITE_STATUS_TYPE, " +
+    public int update(int id, Instant date, SiteStatus status, boolean notify, int userId) {
+        String UPDATE_SQL = "UPDATE changelog SET change_date = ?, site_status = ?::SITE_STATUS_TYPE, notify = ?, " +
                             "modified_date = now(), user_id = ? WHERE id = ? RETURNING site_id";
-        return getJdbcTemplate().queryForObject(UPDATE_SQL, Integer.class, toTimestamp(date), status.toString(), userId, id);
+        return getJdbcTemplate().queryForObject(UPDATE_SQL, Integer.class, toTimestamp(date), status.toString(), notify, userId, id);
     }
 
     /* Returns map <siteId, days at current status> */

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogEdit.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogEdit.java
@@ -28,25 +28,27 @@ public class ChangeLogEdit implements Comparable<ChangeLogEdit> {
     // PERMIT, CONSTRUCTION, OPEN
     private SiteStatus siteStatus;
 
+    private boolean notify;
     private int userId;
     private String username;
 
     /**
      * Factory method with all fields required to persist.
      */
-    public static ChangeLogEdit toPersist(int siteId, ChangeType changeType, SiteStatus siteStatus, Instant date, Instant modifiedInstant, int userId) {
-        return new ChangeLogEdit(siteId, changeType, siteStatus, date, modifiedInstant, userId);
+    public static ChangeLogEdit toPersist(int siteId, ChangeType changeType, SiteStatus siteStatus, Instant date, Instant modifiedInstant, boolean notify, int userId) {
+        return new ChangeLogEdit(siteId, changeType, siteStatus, date, modifiedInstant, notify, userId);
     }
 
     public ChangeLogEdit() {
     }
 
-    private ChangeLogEdit(int siteId, ChangeType changeType, SiteStatus siteStatus, Instant date, Instant modifiedInstant, int userId) {
+    private ChangeLogEdit(int siteId, ChangeType changeType, SiteStatus siteStatus, Instant date, Instant modifiedInstant, boolean notify, int userId) {
         this.siteId = siteId;
         this.date = date;
         this.changeType = changeType;
         this.siteStatus = siteStatus;
         this.modifiedInstant = modifiedInstant;
+        this.notify = notify;
         this.userId = userId;
     }
 
@@ -98,6 +100,14 @@ public class ChangeLogEdit implements Comparable<ChangeLogEdit> {
 
     public void setModifiedInstant(Instant modifiedInstant) {
         this.modifiedInstant = modifiedInstant;
+    }
+
+    public boolean getNotify() {
+        return notify;
+    }
+
+    public void setNotify(boolean notify) {
+        this.notify = notify;
     }
 
     public int getUserId() {

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogEdit.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogEdit.java
@@ -1,0 +1,144 @@
+package com.redshiftsoft.tesla.dao.changelog;
+
+import com.google.common.base.Preconditions;
+import com.redshiftsoft.tesla.dao.site.SiteStatus;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents the change logs displayed in the admin interface.
+ * <p>
+ * Detailed per-field changes are in the 'site_change' table and are represented by the
+ * SiteChange class.
+ */
+public class ChangeLogEdit implements Comparable<ChangeLogEdit> {
+
+    private int id;
+
+    private int siteId;
+
+    private Instant date;
+    private Instant modifiedInstant;
+
+    // ADD, UPDATE
+    private ChangeType changeType;
+
+    // PERMIT, CONSTRUCTION, OPEN
+    private SiteStatus siteStatus;
+
+    private int userId;
+    private String username;
+
+    /**
+     * Factory method with all fields required to persist.
+     */
+    public static ChangeLogEdit toPersist(int siteId, ChangeType changeType, SiteStatus siteStatus, Instant date, Instant modifiedInstant, int userId) {
+        return new ChangeLogEdit(siteId, changeType, siteStatus, date, modifiedInstant, userId);
+    }
+
+    public ChangeLogEdit() {
+    }
+
+    private ChangeLogEdit(int siteId, ChangeType changeType, SiteStatus siteStatus, Instant date, Instant modifiedInstant, int userId) {
+        this.siteId = siteId;
+        this.date = date;
+        this.changeType = changeType;
+        this.siteStatus = siteStatus;
+        this.modifiedInstant = modifiedInstant;
+        this.userId = userId;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public Instant getDate() {
+        return date;
+    }
+
+    public void setDate(Instant date) {
+        Preconditions.checkArgument(date != null);
+        this.date = date;
+    }
+
+    public ChangeType getChangeType() {
+        return changeType;
+    }
+
+    public void setChangeType(ChangeType changeType) {
+        Preconditions.checkArgument(changeType != null);
+        this.changeType = changeType;
+    }
+
+    public SiteStatus getSiteStatus() {
+        return siteStatus;
+    }
+
+    public void setSiteStatus(SiteStatus siteStatus) {
+        this.siteStatus = siteStatus;
+    }
+
+    public int getSiteId() {
+        return siteId;
+    }
+
+    public void setSiteId(int siteId) {
+        this.siteId = siteId;
+    }
+
+    public Instant getModifiedInstant() {
+        return modifiedInstant;
+    }
+
+    public void setModifiedInstant(Instant modifiedInstant) {
+        this.modifiedInstant = modifiedInstant;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // java.lang.Object
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    @Override
+    public int compareTo(ChangeLogEdit o) {
+        return this.date.compareTo(o.date);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        return (object == this) ||
+                (object instanceof ChangeLogEdit) &&
+                        (((ChangeLogEdit) object).getIdentityFields().equals(this.getIdentityFields()));
+    }
+
+    @Override
+    public int hashCode() {
+        return getIdentityFields().hashCode();
+    }
+
+    private List<?> getIdentityFields() {
+        return Collections.singletonList(getId());
+    }
+
+}

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogRowMapper.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogRowMapper.java
@@ -37,7 +37,8 @@ public class ChangeLogRowMapper implements RowMapper<ChangeLog> {
         log.setDate(Instant.ofEpochMilli(rs.getTimestamp(c++).getTime()));
         log.setChangeType(ChangeType.valueOf(rs.getString(c++)));
         log.setSiteStatus(SiteStatus.valueOf(rs.getString(c++)));
-        log.setModifiedInstant(Instant.ofEpochMilli(rs.getTimestamp(c).getTime()));
+        log.setModifiedInstant(Instant.ofEpochMilli(rs.getTimestamp(c++).getTime()));
+        log.setNotify(rs.getBoolean(c));
 
         log.setSiteName(rs.getString("site_name"));
 

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/InsertChangeLogPreparedStatementCreator.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/InsertChangeLogPreparedStatementCreator.java
@@ -18,7 +18,7 @@ public class InsertChangeLogPreparedStatementCreator implements PreparedStatemen
 
     @Override
     public PreparedStatement createPreparedStatement(Connection con) throws SQLException {
-        String SQL = "insert into changelog values (DEFAULT,?,?,?::CHANGE_TYPE,?::SITE_STATUS_TYPE,NOW(),?)";
+        String SQL = "insert into changelog values (DEFAULT,?,?,?::CHANGE_TYPE,?::SITE_STATUS_TYPE,NOW(),?,?)";
         PreparedStatement stat = con.prepareStatement(SQL, PreparedStatement.RETURN_GENERATED_KEYS);
 
         int c = 1;
@@ -26,6 +26,7 @@ public class InsertChangeLogPreparedStatementCreator implements PreparedStatemen
         stat.setTimestamp(c++, toTimestamp(changeLog.getDate()));
         stat.setString(c++, changeLog.getChangeType().toString());
         stat.setString(c++, changeLog.getSiteStatus().toString());
+        stat.setBoolean(c++, changeLog.getNotify());
         stat.setInt(c, changeLog.getUserId());
         return stat;
     }

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/InsertChangeLogPreparedStatementCreator.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/InsertChangeLogPreparedStatementCreator.java
@@ -10,22 +10,23 @@ import static com.redshiftsoft.tesla.dao.BaseDAO.toTimestamp;
 
 public class InsertChangeLogPreparedStatementCreator implements PreparedStatementCreator {
 
-    private final ChangeLog changeLog;
+    private final ChangeLogEdit changeLog;
 
-    public InsertChangeLogPreparedStatementCreator(ChangeLog changeLog) {
+    public InsertChangeLogPreparedStatementCreator(ChangeLogEdit changeLog) {
         this.changeLog = changeLog;
     }
 
     @Override
     public PreparedStatement createPreparedStatement(Connection con) throws SQLException {
-        String SQL = "insert into changelog values (DEFAULT,?,?,?::CHANGE_TYPE,?::SITE_STATUS_TYPE,NOW())";
+        String SQL = "insert into changelog values (DEFAULT,?,?,?::CHANGE_TYPE,?::SITE_STATUS_TYPE,NOW(),?)";
         PreparedStatement stat = con.prepareStatement(SQL, PreparedStatement.RETURN_GENERATED_KEYS);
 
         int c = 1;
         stat.setInt(c++, changeLog.getSiteId());
         stat.setTimestamp(c++, toTimestamp(changeLog.getDate()));
         stat.setString(c++, changeLog.getChangeType().toString());
-        stat.setString(c, changeLog.getSiteStatus().toString());
+        stat.setString(c++, changeLog.getSiteStatus().toString());
+        stat.setInt(c, changeLog.getUserId());
         return stat;
     }
 

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/validation/Validations.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/validation/Validations.java
@@ -117,7 +117,7 @@ public class Validations {
                         ") AS g inner join site using (site_id) " +
                         "GROUP BY name, site_id, grp, site_status " +
                         "HAVING COUNT(*) > 1 " +
-                        "ORDER BY min(site_id)")
+                        "ORDER BY site_id")
         );
 
         validationMap.add(
@@ -133,7 +133,11 @@ public class Validations {
                                     "AND i.change_date < o.change_date " +
                                     "AND i.site_status != o.site_status " +
                                     "AND i.site_status != 'PERMIT') " +
-                        "OR site_status = 'CLOSED_PERM'" +
+                  "UNION SELECT site_id, site.name, to_char(opened_date, 'YYYY-MM-DD'), " +
+                               "site_status, to_char(change_date, 'YYYY-MM-DD') " +
+                        "FROM changelog o " +
+                        "INNER JOIN site using (site_id) " +
+                        "WHERE site_status = 'CLOSED_PERM' " +
                         "AND exists (SELECT 'Y' " +
                                     "FROM changelog i " +
                                     "WHERE i.site_id = o.site_id " +

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/validation/Validations.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/validation/Validations.java
@@ -71,14 +71,36 @@ public class Validations {
                         "SELECT * FROM address WHERE address_id NOT IN (SELECT address_id FROM site)")
         );
 
+        validationMap.add(
+                new Validation(ADDRESS, "contintents and gps coordinates do not conflict",
+                        "SELECT site_id, site.name, gps_latitude, gps_longitude, street, city, state, " +
+                               "zip, country.name country, region.name region " +
+                        "FROM address inner join country using (country_id) " +
+                             "inner join region using (region_id) " +
+                             "inner join site using (address_id) " +
+                        "WHERE region.name = 'North America' " +
+                           "and (gps_longitude between -44 and 172 or gps_latitude < 0) " +
+                           "OR region.name = 'Europe' " +
+                           "and (gps_longitude not between -44 and 47 or gps_latitude < 0) " +
+                           "OR region.name = 'Asia Pacific' and gps_longitude between -148 and 24")
+        );
+
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - | CHANGELOG
 
         validationMap.add(
-                new Validation(CHANGE_LOG, "every non-open site has open status entry in changelog", "" +
+                new Validation(CHANGE_LOG, "every site has a changelog entry matching its status", "" +
                         "SELECT s.* " +
                         "FROM site s " +
-                        "LEFT JOIN changelog c on (s.site_id = c.site_id AND s.status = c.site_status) " +
-                        "WHERE c.site_id is null and s.status != 'OPEN'")
+                        "LEFT JOIN changelog c on (s.site_id = c.site_id AND c.site_status = s.status) " +
+                        "WHERE c.site_id is null")
+        );
+
+        validationMap.add(
+                new Validation(CHANGE_LOG, "every closed site has a changelog entry of open status", "" +
+                        "SELECT s.* " +
+                        "FROM site s " +
+                        "LEFT JOIN changelog c on (s.site_id = c.site_id AND c.site_status = 'OPEN') " +
+                        "WHERE c.site_id is null and s.status in ('CLOSED_PERM', 'CLOSED_TEMP')")
         );
 
         validationMap.add(

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/validation/Validations.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/validation/Validations.java
@@ -96,7 +96,7 @@ public class Validations {
         );
 
         validationMap.add(
-                new Validation(CHANGE_LOG, "every closed site has a changelog entry of open status", "" +
+                new Validation(CHANGE_LOG, "every closed site has a prior changelog entry of open status", "" +
                         "SELECT s.* " +
                         "FROM site s " +
                         "LEFT JOIN changelog c on (s.site_id = c.site_id AND c.site_status = 'OPEN') " +
@@ -139,6 +139,15 @@ public class Validations {
                                     "WHERE i.site_id = o.site_id " +
                                     "AND i.change_date > o.change_date) " +
                         "ORDER BY site_id")
+        );
+
+        validationMap.add(
+                new Validation(CHANGE_LOG, "only one change log exists per day for each site", "" +
+                        "SELECT site_id, name, to_char(change_date, 'YYYY-MM-DD') change_date, " +
+                               "array_agg(id ORDER BY id) change_ids, array_agg(site_status ORDER BY id) site_statuses " +
+                        "FROM site inner join changelog using (site_id) " +
+                        "GROUP BY site_id, name, to_char(change_date, 'YYYY-MM-DD') " +
+                        "HAVING count(*) > 1 ORDER BY site_id, to_char(change_date, 'YYYY-MM-DD')")
         );
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - | USER_CONFIG

--- a/service-dao/src/main/sql/schema-changes.sql
+++ b/service-dao/src/main/sql/schema-changes.sql
@@ -5,9 +5,44 @@ set search_path to supercharge;
 
 ALTER TYPE LOGIN_RESULT_TYPE ADD VALUE 'CHANGED';
 
+-- Add notify and user id to changelogs
 alter table changelog add column notify boolean not null default true,
                       add column user_id int NULL, 
                       add constraint fk_changelog_2 foreign key (user_id)
                                                     references users (user_id)
                                      on update cascade on delete cascade;
 
+-- Recreated deleted changelogs with notify set to false
+-- for sites only ever created
+insert into changelog (
+            site_id,
+            change_date,
+            change_type,
+            site_status,
+            modified_date,
+            notify,
+            user_id)
+     select s.site_id,
+           case when date_part('day', opened_date) < date_part('day', change_date)
+                then opened_date
+                else change_date
+           end,
+           'ADD',
+           status,
+           now(),
+           false,
+           sc.user_id
+      from site s
+inner join site_change sc on s.site_id = sc.site_id and sc.version = 1
+     where not exists (select 'Y' from changelog c where c.site_id = s.site_id)
+       and not exists (select 'Y' from site_change i where s.site_id = i.site_id and i.field_name = 'status');
+
+-- Backfill user ids
+update changelog cl
+   set user_id = coalesce((select sc.user_id
+                             from site_change sc
+                            where cl.site_id = sc.site_id
+                              and (field_name = 'status' and new_value = cast(site_status as varchar)
+                                   or version = 1)
+                              and sc.change_date - modified_date between interval'0' and interval'3 seconds')
+                          , cl.user_id);

--- a/service-dao/src/main/sql/schema-changes.sql
+++ b/service-dao/src/main/sql/schema-changes.sql
@@ -5,8 +5,9 @@ set search_path to supercharge;
 
 ALTER TYPE LOGIN_RESULT_TYPE ADD VALUE 'CHANGED';
 
-alter table changelog add column user_id int NULL; 
-alter table changelog add constraint fk_changelog_2
-	foreign key (user_id) references users (user_id)
-    on update cascade
-    on delete cascade;
+alter table changelog add column notify boolean not null default true,
+                      add column user_id int NULL, 
+                      add constraint fk_changelog_2 foreign key (user_id)
+                                                    references users (user_id)
+                                     on update cascade on delete cascade;
+

--- a/service-dao/src/main/sql/schema-changes.sql
+++ b/service-dao/src/main/sql/schema-changes.sql
@@ -4,3 +4,9 @@
 set search_path to supercharge;
 
 ALTER TYPE LOGIN_RESULT_TYPE ADD VALUE 'CHANGED';
+
+alter table changelog add column user_id int NULL; 
+alter table changelog add constraint fk_changelog_2
+	foreign key (user_id) references users (user_id)
+    on update cascade
+    on delete cascade;

--- a/service-dao/src/test/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogDAO_UT.java
+++ b/service-dao/src/test/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogDAO_UT.java
@@ -2,6 +2,7 @@ package com.redshiftsoft.tesla.dao.changelog;
 
 import com.redshiftsoft.tesla.dao.DAOConfiguration;
 import com.redshiftsoft.tesla.dao.TestSiteSaver;
+import com.redshiftsoft.tesla.dao.TestUsers;
 import com.redshiftsoft.tesla.dao.site.Address;
 import com.redshiftsoft.tesla.dao.site.Site;
 import com.redshiftsoft.tesla.dao.site.SiteDAO;
@@ -34,6 +35,8 @@ public class ChangeLogDAO_UT {
     @Resource
     private TestSiteSaver testSiteSaver;
     @Resource
+    private TestUsers testUsers;
+    @Resource
     private SiteDAO siteDAO;
 
     private Site testSite;
@@ -47,7 +50,7 @@ public class ChangeLogDAO_UT {
     public void insert_getById() {
 
         // given
-        ChangeLog changeLogIn = RandomChangeLog.randomChangeLog(testSite.getId());
+        ChangeLogEdit changeLogIn = RandomChangeLog.randomChangeLog(testSite.getId());
         changeLogDAO.insert(changeLogIn);
 
         // when
@@ -85,7 +88,7 @@ public class ChangeLogDAO_UT {
 
     @Test
     public void insert_delete() {
-        ChangeLog changeLogIn = RandomChangeLog.randomChangeLog(testSite.getId());
+        ChangeLogEdit changeLogIn = RandomChangeLog.randomChangeLog(testSite.getId());
         changeLogDAO.insert(changeLogIn);
         int changeLogId = changeLogIn.getId();
         assertTrue(changeLogDAO.exists(changeLogId));
@@ -99,7 +102,7 @@ public class ChangeLogDAO_UT {
 
     @Test
     public void update_invalidChangeType() {
-        ChangeLog changeLogIn = RandomChangeLog.randomChangeLog(testSite.getId());
+        ChangeLogEdit changeLogIn = RandomChangeLog.randomChangeLog(testSite.getId());
         changeLogDAO.insert(changeLogIn);
         assertThrows(DataIntegrityViolationException.class, () -> {
             jdbcTemplate.update("update changelog set change_type='invalid' where id=?", changeLogIn.getId());
@@ -108,7 +111,7 @@ public class ChangeLogDAO_UT {
 
     @Test
     public void update_emptyChangeType() {
-        ChangeLog changeLogIn = RandomChangeLog.randomChangeLog(testSite.getId());
+        ChangeLogEdit changeLogIn = RandomChangeLog.randomChangeLog(testSite.getId());
         changeLogDAO.insert(changeLogIn);
         assertThrows(DataIntegrityViolationException.class, () -> {
             jdbcTemplate.update("update changelog set change_type=''::CHANGE_TYPE where id=?", changeLogIn.getId());
@@ -130,9 +133,9 @@ public class ChangeLogDAO_UT {
     @Test
     public void getStatusDurations() {
         // given
-        ChangeLog changeLog1 = ChangeLog.toPersist(testSite.getId(), ChangeType.ADD, SiteStatus.PERMIT, Instant.now(), Instant.now());
+        ChangeLogEdit changeLog1 = ChangeLogEdit.toPersist(testSite.getId(), ChangeType.ADD, SiteStatus.PERMIT, Instant.now(), Instant.now(), true, testUsers.createUser().getId());
         changeLogDAO.insert(changeLog1);
-        ChangeLog changeLog2 = ChangeLog.toPersist(testSite.getId(), ChangeType.ADD, SiteStatus.CONSTRUCTION, Instant.now(), Instant.now());
+        ChangeLogEdit changeLog2 = ChangeLogEdit.toPersist(testSite.getId(), ChangeType.ADD, SiteStatus.CONSTRUCTION, Instant.now(), Instant.now(), false, testUsers.createUser().getId());
         changeLogDAO.insert(changeLog2);
         testSite.setStatus(SiteStatus.CONSTRUCTION);
         siteDAO.update(testSite);

--- a/service-dao/src/test/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogDAO_UT.java
+++ b/service-dao/src/test/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogDAO_UT.java
@@ -7,6 +7,8 @@ import com.redshiftsoft.tesla.dao.site.Address;
 import com.redshiftsoft.tesla.dao.site.Site;
 import com.redshiftsoft.tesla.dao.site.SiteDAO;
 import com.redshiftsoft.tesla.dao.site.SiteStatus;
+import com.redshiftsoft.tesla.dao.user.User;
+import com.redshiftsoft.tesla.dao.user.UserDAO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,9 +37,9 @@ public class ChangeLogDAO_UT {
     @Resource
     private TestSiteSaver testSiteSaver;
     @Resource
-    private TestUsers testUsers;
-    @Resource
     private SiteDAO siteDAO;
+    @Resource
+    private UserDAO userDAO;
 
     private Site testSite;
 
@@ -133,9 +135,11 @@ public class ChangeLogDAO_UT {
     @Test
     public void getStatusDurations() {
         // given
-        ChangeLogEdit changeLog1 = ChangeLogEdit.toPersist(testSite.getId(), ChangeType.ADD, SiteStatus.PERMIT, Instant.now(), Instant.now(), true, testUsers.createUser().getId());
+        User user = TestUsers.createUser();
+        userDAO.insert(user);
+        ChangeLogEdit changeLog1 = ChangeLogEdit.toPersist(testSite.getId(), ChangeType.ADD, SiteStatus.PERMIT, Instant.now(), Instant.now(), true, user.getId());
         changeLogDAO.insert(changeLog1);
-        ChangeLogEdit changeLog2 = ChangeLogEdit.toPersist(testSite.getId(), ChangeType.ADD, SiteStatus.CONSTRUCTION, Instant.now(), Instant.now(), false, testUsers.createUser().getId());
+        ChangeLogEdit changeLog2 = ChangeLogEdit.toPersist(testSite.getId(), ChangeType.ADD, SiteStatus.CONSTRUCTION, Instant.now(), Instant.now(), false, user.getId());
         changeLogDAO.insert(changeLog2);
         testSite.setStatus(SiteStatus.CONSTRUCTION);
         siteDAO.update(testSite);

--- a/service-dao/src/test/java/com/redshiftsoft/tesla/dao/changelog/RandomChangeLog.java
+++ b/service-dao/src/test/java/com/redshiftsoft/tesla/dao/changelog/RandomChangeLog.java
@@ -9,12 +9,13 @@ class RandomChangeLog {
 
     private static final RandomUtils random = RandomUtils.fast();
 
-    public static ChangeLog randomChangeLog(int siteId) {
-        ChangeLog changeLogIn = new ChangeLog();
+    public static ChangeLogEdit randomChangeLog(int siteId) {
+        ChangeLogEdit changeLogIn = new ChangeLogEdit();
         changeLogIn.setSiteId(siteId);
         changeLogIn.setDate(Instant.ofEpochMilli(random.getLong(1, 1_000_000_000)));
         changeLogIn.setChangeType(random.getElement(ChangeType.values()));
         changeLogIn.setSiteStatus(random.getElement(SiteStatus.values()));
+        changeLogIn.setNotify(random.getBoolean());
         return changeLogIn;
     }
 }

--- a/service-dao/src/test/java/com/redshiftsoft/tesla/dao/validation/ValidationDAO_UT.java
+++ b/service-dao/src/test/java/com/redshiftsoft/tesla/dao/validation/ValidationDAO_UT.java
@@ -25,6 +25,6 @@ public class ValidationDAO_UT {
     public void doValidations() {
         Collection<ValidationResult> results = validationDAO.doValidations();
 
-        assertEquals(16, results.size());
+        assertEquals(17, results.size());
     }
 }

--- a/service-dao/src/test/java/com/redshiftsoft/tesla/dao/validation/ValidationDAO_UT.java
+++ b/service-dao/src/test/java/com/redshiftsoft/tesla/dao/validation/ValidationDAO_UT.java
@@ -25,6 +25,6 @@ public class ValidationDAO_UT {
     public void doValidations() {
         Collection<ValidationResult> results = validationDAO.doValidations();
 
-        assertEquals(14, results.size());
+        assertEquals(16, results.size());
     }
 }

--- a/service-dao/src/test/java/com/redshiftsoft/tesla/dao/validation/ValidationDAO_UT.java
+++ b/service-dao/src/test/java/com/redshiftsoft/tesla/dao/validation/ValidationDAO_UT.java
@@ -25,6 +25,6 @@ public class ValidationDAO_UT {
     public void doValidations() {
         Collection<ValidationResult> results = validationDAO.doValidations();
 
-        assertEquals(11, results.size());
+        assertEquals(14, results.size());
     }
 }

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/json/LocalDateTimeSerializer.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/json/LocalDateTimeSerializer.java
@@ -6,15 +6,16 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 
 public class LocalDateTimeSerializer extends JsonSerializer<LocalDateTime> {
 
-    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssxxx");
 
     @Override
     public void serialize(LocalDateTime value, JsonGenerator jsonGenerator, SerializerProvider provider) throws IOException {
-        jsonGenerator.writeString(FORMATTER.format(value));
+        jsonGenerator.writeString(FORMATTER.format(value.atZone(ZoneId.of("America/Chicago"))));
     }
 }

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/account/LoginAttemptDTO.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/account/LoginAttemptDTO.java
@@ -3,19 +3,19 @@ package com.redshiftsoft.tesla.web.mvc.account;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.redshiftsoft.tesla.dao.login.LoginResult;
 import com.redshiftsoft.tesla.dao.login.LoginType;
-import com.redshiftsoft.tesla.web.json.LocalDateTimeSerializer;
+import com.redshiftsoft.tesla.web.json.InstantSerializer;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public class LoginAttemptDTO {
 
-    private LocalDateTime date;
+    private Instant date;
     private LoginResult result;
     private LoginType type;
     private String remoteIP;
     private String locale;
 
-    public void setDate(LocalDateTime date) {
+    public void setDate(Instant date) {
         this.date = date;
     }
 
@@ -35,8 +35,8 @@ public class LoginAttemptDTO {
         this.locale = locale;
     }
 
-    @JsonSerialize(using = LocalDateTimeSerializer.class)
-    public LocalDateTime getDate() {
+    @JsonSerialize(using = InstantSerializer.class)
+    public Instant getDate() {
         return date;
     }
 

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/account/LoginAttemptDTOFunction.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/account/LoginAttemptDTOFunction.java
@@ -2,15 +2,13 @@ package com.redshiftsoft.tesla.web.mvc.account;
 
 import com.redshiftsoft.tesla.dao.login.LoginAttempt;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.function.Function;
 
 public class LoginAttemptDTOFunction implements Function<LoginAttempt, LoginAttemptDTO> {
     @Override
     public LoginAttemptDTO apply(LoginAttempt loginAttempt) {
         LoginAttemptDTO dto = new LoginAttemptDTO();
-        dto.setDate(LocalDateTime.ofInstant(loginAttempt.getDate(), ZoneId.systemDefault()));
+        dto.setDate(loginAttempt.getDate());
         dto.setResult(loginAttempt.getResult());
         dto.setType(loginAttempt.getType());
         dto.setRemoteIP(loginAttempt.getRemoteIP());

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
@@ -103,9 +103,9 @@ public class ChangeLogController {
 
     @PreAuthorize("hasAnyRole('editor')")
     @Transactional
-    @RequestMapping(method = RequestMethod.GET, value = "/changes/delete/{changeId}")
+    @RequestMapping(method = RequestMethod.POST, value = "/changes/delete")
     @ResponseBody
-    public void deleteChange(@PathVariable Integer changeId) {
+    public void deleteChange(@RequestParam Integer changeId) {
         LOG.info("Deleting change: " + changeId);
         ChangeLog cl = changeLogDAO.getById(changeId);
         changeLogDAO.delete(changeId);

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
@@ -107,7 +107,11 @@ public class ChangeLogController {
     @ResponseBody
     public void deleteChange(@RequestParam Integer changeId) {
         LOG.info("Deleting change: " + changeId);
+        ChangeLog cl = changeLogDAO.getById(changeId);
         changeLogDAO.delete(changeId);
+        if (ChangeType.ADD.equals(cl.getChangeType())) {
+            changeLogDAO.setFirstToAdded(cl.getSiteId());
+        }
         cachingHandler.reset();
     }
 

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
@@ -115,6 +115,15 @@ public class ChangeLogController {
         cachingHandler.reset();
     }
 
+    @PreAuthorize("hasAnyRole('editor')")
+    @Transactional
+    @RequestMapping(method = RequestMethod.POST, value = "/changes/restoreAdded")
+    @ResponseBody
+    public void restoreAdded(@RequestParam Integer siteId) {
+        changeLogDAO.setFirstToAdded(siteId);
+        cachingHandler.reset();
+    }
+
     private class ChangeLogDTOSupplier implements Supplier<List<ChangeLogDTO>> {
 
         final ChangeLogDTOFunction CONVERTER = new ChangeLogDTOFunction();

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
@@ -103,9 +103,9 @@ public class ChangeLogController {
 
     @PreAuthorize("hasAnyRole('editor')")
     @Transactional
-    @RequestMapping(method = RequestMethod.POST, value = "/changes/delete")
+    @RequestMapping(method = RequestMethod.GET, value = "/changes/delete/{changeId}")
     @ResponseBody
-    public void deleteChange(@RequestParam Integer changeId) {
+    public void deleteChange(@PathVariable Integer changeId) {
         LOG.info("Deleting change: " + changeId);
         ChangeLog cl = changeLogDAO.getById(changeId);
         changeLogDAO.delete(changeId);

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTO.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTO.java
@@ -30,6 +30,7 @@ public class ChangeLogDTO {
     private int stallCount;
     private int powerKilowatt;
     private boolean otherEVs;
+    private boolean notify;
 
     private String siteName;
     private int regionId;
@@ -107,6 +108,14 @@ public class ChangeLogDTO {
 
     public void setOtherEVs(boolean otherEVs) {
         this.otherEVs = otherEVs;
+    }
+
+    public boolean getNotify() {
+        return notify;
+    }
+
+    public void setNotify(boolean notify) {
+        this.notify = notify;
     }
 
     public String getRegion() {

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTOFunction.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTOFunction.java
@@ -17,6 +17,7 @@ public class ChangeLogDTOFunction implements Function<ChangeLog, ChangeLogDTO> {
         changeLogDTO.setStallCount(changeLog.getStallCount());
         changeLogDTO.setPowerKilowatt(changeLog.getPowerKilowatt());
         changeLogDTO.setOtherEVs(changeLog.isOtherEVs());
+        changeLogDTO.setNotify(changeLog.getNotify());
 
         changeLogDTO.setSiteName(changeLog.getSiteName());
         changeLogDTO.setCountryId(changeLog.getCountryId());

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/ChangeLogEditDTO.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/ChangeLogEditDTO.java
@@ -1,0 +1,108 @@
+package com.redshiftsoft.tesla.web.mvc.siteadmin;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.redshiftsoft.tesla.dao.changelog.ChangeType;
+import com.redshiftsoft.tesla.dao.site.SiteStatus;
+import com.redshiftsoft.tesla.web.json.InstantIsoDateSerializer;
+
+import java.time.Instant;
+
+public class ChangeLogEditDTO {
+
+    private int id;
+    private int siteId;
+    private Instant changeDate;
+    private ChangeType changeType;
+    private SiteStatus siteStatus;
+    private int userId;
+    private String username;
+    private SiteChangeDateDTO dateModified;
+
+    /**
+     * Constructors
+     */
+    public ChangeLogEditDTO() {
+    }
+
+    public ChangeLogEditDTO(int id, int siteId, Instant changeDate, ChangeType changeType, SiteStatus siteStatus, int userId, String username, Instant dateModified) {
+        this.id = id;
+        this.siteId = siteId;
+        this.changeDate = changeDate;
+        this.changeType = changeType;
+        this.siteStatus = siteStatus;
+        this.userId = userId;
+        this.username = username;
+        this.dateModified = new SiteChangeDateDTO(dateModified);
+    }
+
+    /**
+     * Getters
+     */
+    public int getId() {
+        return id;
+    }
+
+    public int getSiteId() {
+        return siteId;
+    }
+
+    @JsonSerialize(using = InstantIsoDateSerializer.class)
+    public Instant getChangeDate() {
+        return changeDate;
+    }
+
+    public ChangeType getChangeType() {
+        return changeType;
+    }
+
+    public SiteStatus getSiteStatus() {
+        return siteStatus;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public SiteChangeDateDTO getDateModified() {
+        return dateModified;
+    }
+
+    /**
+     * Setters
+     */
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public void setSiteId(int siteId) {
+        this.siteId = siteId;
+    }
+
+    public void setChangeDate(Instant changeDate) {
+        this.changeDate = changeDate;
+    }
+
+    public void setChangeType(ChangeType changeType) {
+        this.changeType = changeType;
+    }
+
+    public void setSiteStatus(SiteStatus siteStatus) {
+        this.siteStatus = siteStatus;
+    }
+
+    public void setUserId(int id) {
+        this.userId = userId;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setDateModified(Instant dateModified) {
+        this.dateModified = new SiteChangeDateDTO(dateModified);
+    }
+}

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/ChangeLogEditDTO.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/ChangeLogEditDTO.java
@@ -14,6 +14,7 @@ public class ChangeLogEditDTO {
     private Instant changeDate;
     private ChangeType changeType;
     private SiteStatus siteStatus;
+    private boolean notify;
     private int userId;
     private String username;
     private SiteChangeDateDTO dateModified;
@@ -24,12 +25,13 @@ public class ChangeLogEditDTO {
     public ChangeLogEditDTO() {
     }
 
-    public ChangeLogEditDTO(int id, int siteId, Instant changeDate, ChangeType changeType, SiteStatus siteStatus, int userId, String username, Instant dateModified) {
+    public ChangeLogEditDTO(int id, int siteId, Instant changeDate, ChangeType changeType, SiteStatus siteStatus, boolean notify, int userId, String username, Instant dateModified) {
         this.id = id;
         this.siteId = siteId;
         this.changeDate = changeDate;
         this.changeType = changeType;
         this.siteStatus = siteStatus;
+        this.notify = notify;
         this.userId = userId;
         this.username = username;
         this.dateModified = new SiteChangeDateDTO(dateModified);
@@ -57,6 +59,10 @@ public class ChangeLogEditDTO {
 
     public SiteStatus getSiteStatus() {
         return siteStatus;
+    }
+
+    public boolean getNotify() {
+        return notify;
     }
 
     public int getUserId() {
@@ -92,6 +98,10 @@ public class ChangeLogEditDTO {
 
     public void setSiteStatus(SiteStatus siteStatus) {
         this.siteStatus = siteStatus;
+    }
+
+    public void setNotify(boolean notify) {
+        this.notify = notify;
     }
 
     public void setUserId(int id) {

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/ChangeLogEditDTOFunction.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/ChangeLogEditDTOFunction.java
@@ -1,0 +1,25 @@
+package com.redshiftsoft.tesla.web.mvc.siteadmin;
+
+import com.redshiftsoft.tesla.dao.changelog.ChangeLogEdit;
+
+import java.util.function.Function;
+
+public class ChangeLogEditDTOFunction implements Function<ChangeLogEdit, ChangeLogEditDTO> {
+
+    @Override
+    public ChangeLogEditDTO apply(ChangeLogEdit cl) {
+        ChangeLogEditDTO changeLogDTO = new ChangeLogEditDTO();
+
+        changeLogDTO.setId(cl.getId());
+        changeLogDTO.setSiteId(cl.getSiteId());
+        changeLogDTO.setChangeDate(cl.getDate());
+        changeLogDTO.setChangeType(cl.getChangeType());
+        changeLogDTO.setSiteStatus(cl.getSiteStatus());
+        changeLogDTO.setUserId(cl.getUserId());
+        changeLogDTO.setUsername(cl.getUsername());
+        changeLogDTO.setDateModified(cl.getModifiedInstant());
+
+        return changeLogDTO;
+    }
+
+}

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/ChangeLogEditDTOFunction.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/ChangeLogEditDTOFunction.java
@@ -15,6 +15,7 @@ public class ChangeLogEditDTOFunction implements Function<ChangeLogEdit, ChangeL
         changeLogDTO.setChangeDate(cl.getDate());
         changeLogDTO.setChangeType(cl.getChangeType());
         changeLogDTO.setSiteStatus(cl.getSiteStatus());
+        changeLogDTO.setNotify(cl.getNotify());
         changeLogDTO.setUserId(cl.getUserId());
         changeLogDTO.setUsername(cl.getUsername());
         changeLogDTO.setDateModified(cl.getModifiedInstant());

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/SiteDiffLogger.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/SiteDiffLogger.java
@@ -28,7 +28,7 @@ public class SiteDiffLogger {
     /**
      * Record the edit of an EXISTING site in the site changes table.
      */
-    public void record(User user, Site oldSite, Site newSite) {
+    public boolean record(User user, Site oldSite, Site newSite) {
 
         int nextVersion = oldSite.getVersion() + 1;
         SiteChangeBuilder builder = new SiteChangeBuilder(oldSite.getId(), user.getId(), nextVersion, Instant.now());
@@ -57,7 +57,11 @@ public class SiteDiffLogger {
         diff(builder, "address.zip", oldSite.getAddress().getZip(), newSite.getAddress().getZip());
         diff(builder, "address.countryId", oldSite.getAddress().getCountryId(), newSite.getAddress().getCountryId());
 
+        if (builder.getChangeList().size() == 0) {
+            return false;
+        }
         siteChangesDAO.insert(builder.getChangeList());
+        return true;
     }
 
     private static void diff(SiteChangeBuilder builder, String fieldName, Object a, Object b) {

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/SiteEditController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/SiteEditController.java
@@ -1,10 +1,11 @@
 package com.redshiftsoft.tesla.web.mvc.siteadmin;
 
 import com.google.common.collect.Lists;
-import com.redshiftsoft.tesla.dao.changelog.ChangeLog;
+import com.redshiftsoft.tesla.dao.changelog.ChangeLogEdit;
 import com.redshiftsoft.tesla.dao.changelog.ChangeLogDAO;
 import com.redshiftsoft.tesla.dao.changelog.ChangeType;
 import com.redshiftsoft.tesla.dao.dbinfo.DBInfoDAO;
+import com.redshiftsoft.tesla.dao.LocalDateUtil;
 import com.redshiftsoft.tesla.dao.site.Site;
 import com.redshiftsoft.tesla.dao.site.SiteDAO;
 import com.redshiftsoft.tesla.dao.site.SiteStatus;
@@ -12,6 +13,7 @@ import com.redshiftsoft.tesla.dao.sitechanges.SiteChangeDAO;
 import com.redshiftsoft.tesla.dao.user.User;
 import com.redshiftsoft.tesla.web.filter.Security;
 import com.redshiftsoft.tesla.web.mvc.JsonResponse;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Resource;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -124,18 +128,26 @@ public class SiteEditController {
 
     private JsonResponse handleEdit(User user, Site site) {
         List<String> messages = Lists.newArrayList();
-        messages.add(format("UPDATED site '%s'", site.getName()));
 
         Site oldSite = siteDAO.getById(site.getId());
         SiteStatus oldSiteStatus = oldSite.getStatus();
 
+        boolean changes = siteDiffLogger.record(user, oldSite, site);
+        if (!changes) {
+            messages.add("Nothing to do");
+            return new JsonResponse(JsonResponse.Result.FAIL, messages);
+        }
+
+        messages.add(format("UPDATED site '%s'", site.getName()));
         siteDAO.update(site);
-        siteDiffLogger.record(user, oldSite, site);
 
         if (oldSiteStatus != site.getStatus()) {
-            ChangeLog changeLog = ChangeLog.toPersist(site.getId(), ChangeType.UPDATE, site.getStatus(), Instant.now(), Instant.now());
-            changeLogDAO.insert(changeLog);
-            messages.add(format("INSERTED changelog for '%s' with status %s", site.getName(), changeLog.getSiteStatus()));
+            ChangeLogEdit changeLogEdit = ChangeLogEdit.toPersist(site.getId(), ChangeType.UPDATE, site.getStatus(), Instant.now(), Instant.now(), user.getId());
+            if (changeLogDAO.getSiteList(site.getId()).isEmpty()) {
+                changeLogEdit.setChangeType(ChangeType.ADD);
+            }
+            changeLogDAO.insert(changeLogEdit);
+            messages.add(format("INSERTED changelog for '%s' with status %s", site.getName(), changeLogEdit.getSiteStatus()));
         }
 
         return new SiteEditResponse(site.getId(), messages);
@@ -144,12 +156,12 @@ public class SiteEditController {
     private JsonResponse handleSaveNew(User user, Site site) {
         siteDAO.insert(site);
 
-        ChangeLog changeLog = ChangeLog.toPersist(site.getId(), ChangeType.ADD, site.getStatus(), Instant.now(), Instant.now());
-        changeLogDAO.insert(changeLog);
+        ChangeLogEdit changeLogEdit = ChangeLogEdit.toPersist(site.getId(), ChangeType.ADD, site.getStatus(), Instant.now(), Instant.now(), user.getId());
+        changeLogDAO.insert(changeLogEdit);
         siteDiffLogger.recordNew(user, site);
         return new SiteEditResponse(site.getId(), Lists.newArrayList(
                 format("INSERTED site '%s'", site.getName()),
-                format("INSERTED changelog for '%s' with status %s", site.getName(), changeLog.getSiteStatus())
+                format("INSERTED changelog for '%s' with status %s", site.getName(), changeLogEdit.getSiteStatus())
         ));
     }
 
@@ -166,6 +178,33 @@ public class SiteEditController {
     public void delete(@RequestParam int siteId) {
         siteDAO.delete(siteId);
         dbInfoDAO.setLastModifiedToNow();
+    }
+
+    // - - - - - - - - - -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    //
+    // update a change log
+    //
+    // - - - - - - - - - -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    @PreAuthorize("hasRole('editor')")
+    @RequestMapping(method = RequestMethod.POST, value = "/changeEdit")
+    @ResponseBody
+    @Transactional
+    public List<ChangeLogEditDTO> changeEdit(@RequestParam int changeId,
+                                       @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                                       @RequestParam LocalDate changeDate,
+                                       @RequestParam SiteStatus siteStatus) {
+        User user = Security.user();
+        Instant changeDateInstant = changeDate.atTime(12, 0).atZone(LocalDateUtil.ZONE_ID).toInstant();
+
+        // Update procedure
+        int siteId = changeLogDAO.update(changeId, changeDateInstant, siteStatus, user.getId());
+        List<ChangeLogEdit> changeLogs = changeLogDAO.setFirstToAdded(siteId);
+        dbInfoDAO.setLastModifiedToNow();
+        return changeLogs.stream().map(new ChangeLogEditDTOFunction())
+            .sorted(Comparator.comparing(ChangeLogEditDTO::getChangeDate)
+                        .thenComparing(ChangeLogEditDTO::getId).reversed())
+            .collect(Collectors.toList());
     }
 
 
@@ -190,6 +229,23 @@ public class SiteEditController {
                         x.getOldValue(),
                         x.getNewValue(),
                         x.getChangeDate())).collect(Collectors.toList());
+    }
+
+
+    // - - - - - - - - - -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    //
+    // list change logs for a site
+    //
+    // - - - - - - - - - -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    @PreAuthorize("hasAnyRole('editor')")
+    @RequestMapping(method = RequestMethod.GET, value = "/changeLogEdits")
+    @ResponseBody
+    @Transactional
+    public List<ChangeLogEditDTO> listChangeEdits(@RequestParam int siteId) {
+        return changeLogDAO.getChangeLogEdits(siteId).stream()
+                .map(new ChangeLogEditDTOFunction())
+                .collect(Collectors.toList());
     }
 
 

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/SiteEditDTO.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/siteadmin/SiteEditDTO.java
@@ -41,6 +41,7 @@ public class SiteEditDTO {
 
     /* Power in kW */
     private int powerKiloWatt;
+    private NotifyEnum notify;
     private boolean solarCanopy;
     private boolean battery;
     private boolean otherEVs;
@@ -221,6 +222,14 @@ public class SiteEditDTO {
         this.powerKiloWatt = powerKiloWatt;
     }
 
+    public NotifyEnum getNotify() {
+        return notify;
+    }
+
+    public void setNotify(NotifyEnum notify) {
+        this.notify = notify;
+    }
+
     public boolean isSolarCanopy() {
         return solarCanopy;
     }
@@ -259,6 +268,10 @@ public class SiteEditDTO {
 
     public void setOtherEVs(boolean otherEVs) {
         this.otherEVs = otherEVs;
+    }
+
+    public enum NotifyEnum {
+        yes, log, no
     }
 }
 

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/validation/ValidationController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/validation/ValidationController.java
@@ -1,10 +1,14 @@
 package com.redshiftsoft.tesla.web.mvc.validation;
 
+import com.redshiftsoft.tesla.dao.validation.ValidationCategory;
 import com.redshiftsoft.tesla.dao.validation.ValidationDAO;
 import com.redshiftsoft.tesla.dao.validation.ValidationResult;
+import com.redshiftsoft.tesla.dao.user.User;
+import com.redshiftsoft.tesla.web.filter.Security;
 import com.redshiftsoft.tesla_web_scrape.WebCompare;
 import com.redshiftsoft.tesla_web_scrape.http.WebClient;
 import com.redshiftsoft.tesla_web_scrape.http.WebScrapeResult;
+import com.redshiftsoft.util.StringTools;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import javax.annotation.Resource;
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller
 @RequestMapping("/validation")
@@ -35,7 +40,11 @@ public class ValidationController {
     @RequestMapping(method = RequestMethod.GET, value = "/database")
     @ResponseBody
     public List<ValidationResult> doDatabaseValidations() {
-        return validationDAO.doValidations();
+        User user = Security.user();
+        return validationDAO.doValidations()
+            .stream()
+            .filter(v -> user.hasRole("admin") || !ValidationCategory.USER_CONFIG.equals(v.getValidation().getCategory()))
+            .collect(Collectors.toList());
     }
 
 

--- a/service-war/src/test/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTO_UT.java
+++ b/service-war/src/test/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTO_UT.java
@@ -44,6 +44,7 @@ public class ChangeLogDTO_UT {
                 "siteStatus\":\"CONSTRUCTION\",\"" +
                 "stallCount\":19,\"" +
                 "powerKilowatt\":125,\"" +
+                "notify\":false,\"" +
                 "siteName\":\"testSiteName\",\"" +
                 "regionId\":9999,\"" +
                 "region\":\"testRegion\",\"" +

--- a/service-war/src/test/java/com/redshiftsoft/tesla/web/mvc/feature/FeatureDTO_UT.java
+++ b/service-war/src/test/java/com/redshiftsoft/tesla/web/mvc/feature/FeatureDTO_UT.java
@@ -22,7 +22,7 @@ public class FeatureDTO_UT {
 
         String result = new ObjectMapper().writeValueAsString(dto);
 
-        assertEquals("{\"id\":123456,\"title\":\"the title\",\"description\":\"This is a test description.\",\"addedDate\":\"2016-12-29\",\"modifiedDate\":\"2017-10-14 17:30:45\"}", result);
+        assertEquals("{\"id\":123456,\"title\":\"the title\",\"description\":\"This is a test description.\",\"addedDate\":\"2016-12-29\",\"modifiedDate\":\"2017-10-14 17:30:45-05:00\"}", result);
 
     }
 

--- a/web-scrape/src/main/java/com/redshiftsoft/tesla_web_scrape/htmloutput/HtmlOutputFieldComparison.java
+++ b/web-scrape/src/main/java/com/redshiftsoft/tesla_web_scrape/htmloutput/HtmlOutputFieldComparison.java
@@ -136,8 +136,8 @@ class HtmlOutputFieldComparison {
     private static boolean locationCompare(Tr localRow, Site site, Tr teslaRow, TeslaSite teslaSite) {
         double distanceKm = Distances.distanceKm(site, teslaSite);
         double distanceM = distanceKm * 1000.0;
-        Td localCell = new Td(String.format("%,.9f,%,.9f", site.getGps().getLatitude(), site.getGps().getLongitude()));
-        Td teslaCell = new Td(String.format("%,.9f,%,.9f", teslaSite.getLatitude(), teslaSite.getLongitude()));
+        Td localCell = new Td(String.format("%,.9f, %,.9f", site.getGps().getLatitude(), site.getGps().getLongitude()));
+        Td teslaCell = new Td(String.format("%,.9f, %,.9f", teslaSite.getLatitude(), teslaSite.getLongitude()));
         localRow.add(localCell);
         teslaRow.add(teslaCell);
         if (distanceM > 100.0) {


### PR DESCRIPTION
Supports admin-side PR by adding a "notify" column to changelogs, allowing editing and manual creation of changelogs, and validations to support maintenance.