### PR TITLE
Add previous status to changelog records returned via API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .idea/
 *.iml
 
+# VSCode
+.vscode/
+
 # Build Files
 target/
 

--- a/database/sql/04-tables.sql
+++ b/database/sql/04-tables.sql
@@ -188,7 +188,7 @@ create table changelog
         on delete cascade
 );
 alter sequence changelog_id_seq restart with 100000;
--- CREATE INDEX changelog_site_id_change_date ON changelog (site_id, change_date);
+CREATE INDEX changelog_site_id_change_date ON changelog (site_id, change_date);
 
 -- -----------------------------------------------------------
 -- SITE CHANGES

--- a/database/sql/04-tables.sql
+++ b/database/sql/04-tables.sql
@@ -121,30 +121,6 @@ create table site_stall_count
 );
 
 -- -----------------------------------------------------------
--- CHANGE LOG
--- -----------------------------------------------------------
-CREATE TYPE CHANGE_TYPE AS ENUM ('ADD', 'UPDATE');
-
-create table changelog
-(
-    id            serial primary key,
-    site_id       int              not null,
-    change_date   timestamptz      not null,
-    change_type   change_type      not null,
-    site_status   site_status_type not null,
-    modified_date timestamptz      not null default current_timestamp,
-    notify        boolean          not null default true,
-    user_id       int              null,
-    CONSTRAINT fk_changelog_1 foreign key (site_id) references site (site_id)
-        on update cascade
-        on delete cascade,
-    CONSTRAINT fk_changelog_2 foreign key (user_id) references users (user_id)
-        on update cascade
-        on delete cascade
-);
-alter sequence changelog_id_seq restart with 100000;
-
--- -----------------------------------------------------------
 -- role
 -- -----------------------------------------------------------
 create table roles
@@ -188,6 +164,30 @@ create table user_role
     constraint user_role_user_id_role_id_unique unique (user_id, role_id)
 );
 
+
+-- -----------------------------------------------------------
+-- CHANGE LOG
+-- -----------------------------------------------------------
+CREATE TYPE CHANGE_TYPE AS ENUM ('ADD', 'UPDATE');
+
+create table changelog
+(
+    id            serial primary key,
+    site_id       int              not null,
+    change_date   timestamptz      not null,
+    change_type   change_type      not null,
+    site_status   site_status_type not null,
+    modified_date timestamptz      not null default current_timestamp,
+    notify        boolean          not null default true,
+    user_id       int              null,
+    CONSTRAINT fk_changelog_1 foreign key (site_id) references site (site_id)
+        on update cascade
+        on delete cascade,
+    CONSTRAINT fk_changelog_2 foreign key (user_id) references users (user_id)
+        on update cascade
+        on delete cascade
+);
+alter sequence changelog_id_seq restart with 100000;
 
 -- -----------------------------------------------------------
 -- SITE CHANGES

--- a/database/sql/04-tables.sql
+++ b/database/sql/04-tables.sql
@@ -185,11 +185,10 @@ create table changelog
         on delete cascade,
     CONSTRAINT fk_changelog_2 foreign key (user_id) references users (user_id)
         on update cascade
-        on delete cascade,
-    CONSTRAINT unique_site_id_change_date UNIQUE (site_id, change_date)
+        on delete cascade
 );
 alter sequence changelog_id_seq restart with 100000;
-CREATE INDEX changelog_site_id_change_date ON changelog (site_id, change_date);
+-- CREATE INDEX changelog_site_id_change_date ON changelog (site_id, change_date);
 
 -- -----------------------------------------------------------
 -- SITE CHANGES

--- a/database/sql/04-tables.sql
+++ b/database/sql/04-tables.sql
@@ -185,9 +185,11 @@ create table changelog
         on delete cascade,
     CONSTRAINT fk_changelog_2 foreign key (user_id) references users (user_id)
         on update cascade
-        on delete cascade
+        on delete cascade,
+    CONSTRAINT unique_site_id_change_date UNIQUE (site_id, change_date)
 );
 alter sequence changelog_id_seq restart with 100000;
+CREATE INDEX changelog_site_id_change_date ON changelog (site_id, change_date);
 
 -- -----------------------------------------------------------
 -- SITE CHANGES

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLog.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLog.java
@@ -37,6 +37,7 @@ public class ChangeLog implements Comparable<ChangeLog> {
 
     // PERMIT, CONSTRUCTION, OPEN
     private SiteStatus siteStatus;
+    private SiteStatus prevStatus;
 
     private boolean notify;
     private int stallCount;
@@ -75,6 +76,14 @@ public class ChangeLog implements Comparable<ChangeLog> {
 
     public void setSiteStatus(SiteStatus siteStatus) {
         this.siteStatus = siteStatus;
+    }
+
+    public SiteStatus getPrevStatus() {
+        return prevStatus;
+    }
+
+    public void setPrevStatus(SiteStatus prevStatus) {
+        this.prevStatus = prevStatus;
     }
 
     public boolean getNotify() {

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogRowMapper.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogRowMapper.java
@@ -19,12 +19,20 @@ public class ChangeLogRowMapper implements RowMapper<ChangeLog> {
             "       a.state as state, " +
             "       s.stall_count as stall_count, " +
             "       s.power_kwatt as power_kwatt, " +
-            "       s.other_evs as other_evs " +
+            "       s.other_evs as other_evs, " +
+            "       pcl.site_status as prev_status " +
             "from changelog cl  " +
             "join site      s on cl.site_id   = s.site_id " +
             "join address   a on s.address_id = a.address_id " +
             "join country   c on a.country_id = c.country_id " +
-            "join region    r on r.region_id  = c.region_id ";
+            "join region    r on r.region_id  = c.region_id " +
+            "left join changelog pcl " +
+            "    on pcl.site_id = cl.site_id " +
+            "    and pcl.id = (" +
+            "        select max(id) from changelog where site_id = cl.site_id and change_date = (" +
+            "            select max(change_date) from changelog where site_id = cl.site_id and change_date < cl.change_date" +
+            "        )" +
+            "    )";
 
     @Override
     public ChangeLog mapRow(ResultSet rs, int rowNum) throws SQLException {
@@ -53,6 +61,7 @@ public class ChangeLogRowMapper implements RowMapper<ChangeLog> {
         log.setStallCount(rs.getInt("stall_count"));
         log.setPowerKilowatt(rs.getInt("power_kwatt"));
         log.setOtherEVs(rs.getBoolean("other_evs"));
+        log.setPrevStatus(SiteStatus.valueOf(rs.getString("prev_status")));
 
         return log;
     }

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogRowMapper.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogRowMapper.java
@@ -64,7 +64,7 @@ public class ChangeLogRowMapper implements RowMapper<ChangeLog> {
 
         String prevStatus = rs.getString("prev_status");
         if (prevStatus != null) {
-            log.setPrevStatus(SiteStatus.valueOf(rs.getString("prev_status")));
+            log.setPrevStatus(SiteStatus.valueOf(prevStatus));
         }
 
         return log;

--- a/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogRowMapper.java
+++ b/service-dao/src/main/java/com/redshiftsoft/tesla/dao/changelog/ChangeLogRowMapper.java
@@ -61,7 +61,11 @@ public class ChangeLogRowMapper implements RowMapper<ChangeLog> {
         log.setStallCount(rs.getInt("stall_count"));
         log.setPowerKilowatt(rs.getInt("power_kwatt"));
         log.setOtherEVs(rs.getBoolean("other_evs"));
-        log.setPrevStatus(SiteStatus.valueOf(rs.getString("prev_status")));
+
+        String prevStatus = rs.getString("prev_status");
+        if (prevStatus != null) {
+            log.setPrevStatus(SiteStatus.valueOf(rs.getString("prev_status")));
+        }
 
         return log;
     }

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
@@ -43,8 +43,8 @@ public class ChangeLogController {
         if (count != null) {
             int toIndex = Math.min(count, changes.size());
             changes = changes.subList(0, toIndex);
+            LOG.info("allChanges first: " + changes.get(0));
         }
-        LOG.info("allChanges first: " + changes.get(0));
         return changes;
     }
 

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
@@ -44,6 +44,7 @@ public class ChangeLogController {
             int toIndex = Math.min(count, changes.size());
             changes = changes.subList(0, toIndex);
         }
+        LOG.info("allChanges first: " + changes.get(0));
         return changes;
     }
 

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogController.java
@@ -43,7 +43,6 @@ public class ChangeLogController {
         if (count != null) {
             int toIndex = Math.min(count, changes.size());
             changes = changes.subList(0, toIndex);
-            LOG.info("allChanges first: " + changes.get(0));
         }
         return changes;
     }

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTO.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTO.java
@@ -16,6 +16,7 @@ import java.time.Instant;
  * "siteName"     : "Canmore, Canada",
  * "changeType"   : "UPDATE",
  * "siteStatus"   : "CONSTRUCTION",
+ * "prevStatus"   : "PERMIT",
  * "date"         : "2014-11-06",
  * "dateFormatted": "Thu, Nov 6 2014"
  * }

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTO.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTO.java
@@ -27,6 +27,7 @@ public class ChangeLogDTO {
     private Instant date;
     private ChangeType changeType;
     private SiteStatus siteStatus;
+    private SiteStatus prevStatus;
     private int stallCount;
     private int powerKilowatt;
     private boolean otherEVs;
@@ -83,6 +84,14 @@ public class ChangeLogDTO {
 
     public void setSiteStatus(SiteStatus siteStatus) {
         this.siteStatus = siteStatus;
+    }
+
+    public SiteStatus getPrevStatus() {
+        return prevStatus;
+    }
+
+    public void setPrevStatus(SiteStatus prevStatus) {
+        this.prevStatus = prevStatus;
     }
 
     public int getStallCount() {

--- a/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTOFunction.java
+++ b/service-war/src/main/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTOFunction.java
@@ -14,6 +14,7 @@ public class ChangeLogDTOFunction implements Function<ChangeLog, ChangeLogDTO> {
         changeLogDTO.setChangeType(changeLog.getChangeType());
         changeLogDTO.setDate(changeLog.getDate());
         changeLogDTO.setSiteStatus(changeLog.getSiteStatus());
+        changeLogDTO.setPrevStatus(changeLog.getPrevStatus());
         changeLogDTO.setStallCount(changeLog.getStallCount());
         changeLogDTO.setPowerKilowatt(changeLog.getPowerKilowatt());
         changeLogDTO.setOtherEVs(changeLog.isOtherEVs());

--- a/service-war/src/test/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTO_UT.java
+++ b/service-war/src/test/java/com/redshiftsoft/tesla/web/mvc/changelog/ChangeLogDTO_UT.java
@@ -29,6 +29,7 @@ public class ChangeLogDTO_UT {
         dto.setCountry("testCountry");
         dto.setState("testState");
         dto.setSiteStatus(SiteStatus.CONSTRUCTION);
+        dto.setPrevStatus(SiteStatus.PERMIT);
         dto.setStallCount(19);
         dto.setPowerKilowatt(125);
 
@@ -42,6 +43,7 @@ public class ChangeLogDTO_UT {
                 "date\":\"2017-11-20\",\"" +
                 "changeType\":\"UPDATE\",\"" +
                 "siteStatus\":\"CONSTRUCTION\",\"" +
+                "prevStatus\":\"PERMIT\",\"" +
                 "stallCount\":19,\"" +
                 "powerKilowatt\":125,\"" +
                 "notify\":false,\"" +


### PR DESCRIPTION
This does NOT add a new column to the database itself, it computes previous status as needed. It does add a new index to make the computation faster. If needed, we should be able to add and populate a prevStatus column.